### PR TITLE
[AI] Refactor mirror change detection and configuration writing

### DIFF
--- a/Unilyric/src/app_handlers.rs
+++ b/Unilyric/src/app_handlers.rs
@@ -1022,29 +1022,27 @@ impl UniLyricApp {
                     {
                         let old_settings = self.app_settings.lock().unwrap();
                         let new_mirror = &settings.amll_mirror;
-                        if &old_settings.amll_mirror != new_mirror {
-                            let core_config = CoreAmllConfig {
-                                mirror: new_mirror.clone().into(),
-                            };
-                            match serde_json::to_string_pretty(&core_config) {
-                                Ok(json_string) => {
-                                    if let Ok(config_path) =
-                                        lyrics_helper_rs::config::get_config_file_path(
-                                            "amll_config.json",
-                                        )
-                                    {
-                                        if let Err(e) = std::fs::write(&config_path, json_string) {
-                                            error!("[Settings] 写入 amll_config.json 失败: {}", e);
-                                        } else {
-                                            mirror_changed = true;
-                                        }
-                                    } else {
-                                        error!("[Settings] 无法获取 amll_config.json 的路径");
+                        mirror_changed = &old_settings.amll_mirror != new_mirror;
+
+                        let core_config = CoreAmllConfig {
+                            mirror: new_mirror.clone().into(),
+                        };
+                        match serde_json::to_string_pretty(&core_config) {
+                            Ok(json_string) => {
+                                if let Ok(config_path) =
+                                    lyrics_helper_rs::config::get_config_file_path(
+                                        "amll_config.json",
+                                    )
+                                {
+                                    if let Err(e) = std::fs::write(&config_path, json_string) {
+                                        error!("[Settings] 写入 amll_config.json 失败: {}", e);
                                     }
+                                } else {
+                                    error!("[Settings] 无法获取 amll_config.json 的路径");
                                 }
-                                Err(e) => {
-                                    error!("[Settings] 序列化核心库 AMLL 配置失败: {}", e);
-                                }
+                            }
+                            Err(e) => {
+                                error!("[Settings] 序列化核心库 AMLL 配置失败: {}", e);
                             }
                         }
                     }


### PR DESCRIPTION
已调整为每次保存设置都会写入 AMLL 核心配置文件，确保 %APPDATA%\lyrics-helper\amll_config.json 始终与设置同步；mirror_changed只负责控制提示，而不再影响是否写入。改动在 app_handlers.rs:1016-1052。

如果你要验证效果，可以：

保存一次设置后检查 %APPDATA%\lyrics-helper\amll_config.json 是否生成并更新
重新加载提供商或重启应用观察日志是否走 GitHub